### PR TITLE
意図しない記録表示の修正

### DIFF
--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -23,11 +23,11 @@
     <p class="text-gray-600 whitespace-pre-line"><%= @work.memo.presence || "メモはありません。" %></p>
   </div>
 
-  <!-- 作成・更新日時 
+  <%# 作成・更新日時 
   <div class="text-sm text-gray-500 mb-6">
-    <p>作成日: <%= l(@work.created_at, format: :long) %></p>
+    <p>ポケモン: <%= l(@work.created_at, format: :long) %></p>
     <p>最終更新日: <%= l(@work.updated_at, format: :long) %></p>
-  </div> -->
+  </div> %>
 
   <div class="mt-4 flex justify-end space-x-2">
           <%= link_to '編集', edit_work_path(@work), class: 'px-3 py-1 bg-blue-500 text-white text-sm rounded hover:bg-blue-600' %>


### PR DESCRIPTION
「お腹すいたポケモン」という記事が最初から２件表記されてしまう問題を修正しました。
本番環境での挙動確認になるため、再度修正する可能性があります。